### PR TITLE
Fixed exception in /lg end

### DIFF
--- a/src/main/java/fr/leomelki/loupgarou/MainLg.java
+++ b/src/main/java/fr/leomelki/loupgarou/MainLg.java
@@ -225,9 +225,14 @@ public class MainLg extends JavaPlugin{
 					sender.sendMessage(prefix+"§aLa position a bien été ajoutée !");
 					return true;
 				}else if(args[0].equalsIgnoreCase("end")) {
-					LGPlayer.thePlayer(Bukkit.getPlayer(args[1])).getGame().cancelWait();
-					LGPlayer.thePlayer(Bukkit.getPlayer(args[1])).getGame().endGame(LGWinType.EQUAL);
-					LGPlayer.thePlayer(Bukkit.getPlayer(args[1])).getGame().broadcastMessage("§cLa partie a été arrêtée de force !");
+					if(args.length < 2) {
+						sender.sendMessage("§4Utilisation : §c/lg end <pseudo>");
+						return true;
+					}
+					LGGame game = LGPlayer.thePlayer(Bukkit.getPlayer(args[1])).getGame();
+					game.cancelWait();
+					game.endGame(LGWinType.EQUAL);
+					game.broadcastMessage("§cLa partie a été arrêtée de force !");
 					return true;
 				}else if(args[0].equalsIgnoreCase("start")) {
 					if(args.length < 2) {

--- a/src/main/java/fr/leomelki/loupgarou/MainLg.java
+++ b/src/main/java/fr/leomelki/loupgarou/MainLg.java
@@ -225,11 +225,20 @@ public class MainLg extends JavaPlugin{
 					sender.sendMessage(prefix+"§aLa position a bien été ajoutée !");
 					return true;
 				}else if(args[0].equalsIgnoreCase("end")) {
-					if(args.length < 2) {
+					if(args.length != 2) {
 						sender.sendMessage("§4Utilisation : §c/lg end <pseudo>");
 						return true;
 					}
-					LGGame game = LGPlayer.thePlayer(Bukkit.getPlayer(args[1])).getGame();
+					Player selected = Bukkit.getPlayer(args[1]);
+					if(selected == null) {
+						sender.sendMessage("§4Erreur : §cLe joueur §4"+args[1]+"§c n'est pas connecté.");
+						return true;
+					}
+					LGGame game = LGPlayer.thePlayer(selected).getGame();
+					if(game == null) {
+						sender.sendMessage("§4Erreur : §cLe joueur §4"+selected.getName()+"§c n'est pas dans une partie.");
+						return true;
+					}
 					game.cancelWait();
 					game.endGame(LGWinType.EQUAL);
 					game.broadcastMessage("§cLa partie a été arrêtée de force !");
@@ -245,6 +254,10 @@ public class MainLg extends JavaPlugin{
 						return true;
 					}
 					LGPlayer lgp = LGPlayer.thePlayer(player);
+					if(lgp.getGame() == null) {
+						sender.sendMessage("§4Erreur : §cLe joueur §4"+lgp.getName()+"§c n'est pas dans une partie.");
+						return true;
+					}
 					if(MainLg.getInstance().getConfig().getList("spawns").size() < lgp.getGame().getMaxPlayers()) {
 						sender.sendMessage("§4Erreur : §cIl n'y a pas assez de points de spawn !");
 						sender.sendMessage("§8§oPour les définir, merci de faire §7/lg addSpawn");


### PR DESCRIPTION
- Ajout de vérification d'arguments
- La game étant supprimée, elle n'est plus trouvée lors du broadcast, et donc génère une NPE. Elle est maintenant conservée pour corriger ça (et aussi optimiser, appeler LGPlayer.thePlayer(XXX) tout le temps c'est une perte de performance, surtout s'il y a beaucoup de joueurs)