### PR TITLE
Correction d'un message lors du Bouffon

### DIFF
--- a/src/main/java/fr/leomelki/loupgarou/roles/RBouffon.java
+++ b/src/main/java/fr/leomelki/loupgarou/roles/RBouffon.java
@@ -90,10 +90,10 @@ public class RBouffon extends Role{
 		List<LGPlayer> choosable = getGame().getVote().getVotes(player);
 		StringJoiner sj = new StringJoiner("§6§o, §6§o§l");
 		for(LGPlayer lgp : choosable)
-			if(lgp.getPlayer() != null && lgp.getPlayer() != player)
+			if(lgp.getPlayer() != null && lgp != player)
 				sj.add(lgp.getName());
 		
-		player.sendMessage("§6§o§l"+sj+"§6§o "+(sj.length() > 1 ? "ont" : "a")+" voté pour toi.");
+		player.sendMessage("§6§o§l"+sj+"§6§o "+(choosable.size() > 1 ? "ont" : "a")+" voté pour toi.");
 				
 		player.choose((choosen)->{
 			if(choosen != null) {


### PR DESCRIPTION
- La comparaison de joueurs était effectuée entre un LGPlayer et un Player bukkit, ce qui était donc toujours valide. Le bouffon pouvait donc ainsi se tuer lui-même s'il avait voté contre lui pendant le tour du village. (J'ai vu plus bas un check de mort annoté comme étant un bug, peut-être est-ce cela ?) Merci IntelliJ pour avoir signalé le problème.
- La mauvaise variable était testée pour mettre la phrase au pluriel, en effet `sj` fais toujours au minimum 2 caractères (longueur minimale d'un pseudo Minecraft). Le message était donc toujours au pluriel, ce qui est désormais corrigé.