### PR TITLE
Fix NullPointerException sur les ArmorStand en 1.15.2 (Issue #37)

### DIFF
--- a/src/main/java/fr/leomelki/loupgarou/classes/LGVote.java
+++ b/src/main/java/fr/leomelki/loupgarou/classes/LGVote.java
@@ -85,7 +85,7 @@ public class LGVote {
     private static DataWatcherObject<Optional<IChatBaseComponent>> az;
     private static DataWatcherObject<Boolean> aA;
     private static DataWatcherObject<Byte> T;
-    private static final EntityArmorStand eas = new EntityArmorStand(null, 0, 0, 0);
+	private static final EntityArmorStand eas = new EntityArmorStand(((CraftWorld)Bukkit.getWorlds().get(0)).getHandle(), 0, 0, 0);
     static {
     	try {
     		Field f = Entity.class.getDeclaredField("az");

--- a/src/main/java/fr/leomelki/loupgarou/classes/LGVote.java
+++ b/src/main/java/fr/leomelki/loupgarou/classes/LGVote.java
@@ -85,7 +85,7 @@ public class LGVote {
     private static DataWatcherObject<Optional<IChatBaseComponent>> az;
     private static DataWatcherObject<Boolean> aA;
     private static DataWatcherObject<Byte> T;
-	private static final EntityArmorStand eas = new EntityArmorStand(((CraftWorld)Bukkit.getWorlds().get(0)).getHandle(), 0, 0, 0);
+    private static final EntityArmorStand eas = new EntityArmorStand(((CraftWorld)Bukkit.getWorlds().get(0)).getHandle(), 0, 0, 0);
     static {
     	try {
     		Field f = Entity.class.getDeclaredField("az");


### PR DESCRIPTION
Permet de corriger #37 
Corrige un NullPointerException sur les ArmorStands dans la classe LGvote (bug qui survient en 1.15.2 avec Paper, mais pas constaté le reste du temps).
Cela a suffit à rendre le plugin compatible pour la 1.15.2 Paper de mon côté.

L'entité est ajoutée dans l'overworld.