### PR TITLE
Update docker + Add CI

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,17 @@
+name: Build Image
+
+on:
+    push:
+        branches:
+            master
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: docker login --username atomgenie --password $DOCKER_SECRET
+              env:
+                DOCKER_SECRET: ${{ secrets.DOCKER_SECRET }}
+            - run: docker-compose -f ./docker-compose.builder.yaml build
+            - run: docker-compose -f ./docker-compose.builder.yaml push

--- a/README.md
+++ b/README.md
@@ -58,23 +58,18 @@ Lien des releases : [Cliquez ici](https://github.com/leomelki/LoupGarou/releases
 
 Vous devez avoir installé `docker` et `docker-compose` sur votre machine
 
-#### Installation du serveur
-```sh
-docker-compose up -d --build
-```
-
 #### Démarage du serveur
 
-Vous devez exécuter la commande suivante à chaque redémarage de votre machine avant de pouvoir continuer
+Pour lancer le serveur, executez cette commande :
 
 ```sh
-docker-compose up -d
+EULA=true docker-compose up -d
 ```
 
-Ainsi, vous pouvez lancer le serveur en utilisant la commande suivante :
+Pour intéragir avec la console Minecraft :
 
 ```sh
-docker-compose exec loup-garou java -jar spigot.jar
+docker-compose exec loup-garou rcon-cli
 ```
 
 Les fichiers relatifs à minecraft se situeront dans le dossier `minecraft_data` 

--- a/docker-compose.builder.yaml
+++ b/docker-compose.builder.yaml
@@ -1,0 +1,8 @@
+version: "3.0"
+
+services:
+    loup-garou:
+        image: atomgenie/loup-garou
+        build:
+            context: .
+            dockerfile: ./docker/Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,12 +2,10 @@ version: "3.0"
 
 services:
     loup-garou:
-        build:
-            context: .
-            dockerfile: ./docker/Dockerfile
-            args:
-                SPIGOT_VERSION: 1.15.1
+        image: atomgenie/loup-garou
         volumes:
-            - ./minecraft_data:/minecraft
+            - ./minecraft_data:/data
         ports:
             - 25565:25565
+        environment:
+            - EULA

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,3 @@
-ARG SPIGOT_VERSION=1.15.1
-
 # Build Loup-Garou project
 FROM maven:3.3-jdk-8 as LOUP_GAROU_BUILDER
 WORKDIR /app
@@ -7,24 +5,14 @@ COPY . .
 RUN mvn clean install
 RUN mvn package
 
-# Build Spigot project
-FROM openjdk:8 AS SPIGOT_BUILDER
-ARG SPIGOT_VERSION
-WORKDIR /spigot
-RUN apt-get update
-ADD https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar buildtools.jar
-RUN git config --global --unset core.autocrlf || true
-RUN java -Xmx1024M -jar buildtools.jar --rev ${SPIGOT_VERSION}
+# Start the minecraft server
+FROM itzg/minecraft-server:latest
 
-# Final server image
-FROM openjdk:8
-ARG SPIGOT_VERSION
-WORKDIR /_minecraft
-COPY --from=LOUP_GAROU_BUILDER /app/target/LoupGarou.jar ./plugins/
-ADD https://github.com/dmulloy2/ProtocolLib/releases/download/4.5.0/ProtocolLib.jar ./plugins
-COPY --from=SPIGOT_BUILDER /spigot/spigot-${SPIGOT_VERSION}.jar ./spigot.jar
+ENV TYPE=SPIGOT
+ENV VERSION=1.15.1
 
-VOLUME /minecraft
-WORKDIR /minecraft
+WORKDIR /plugins
+COPY --from=LOUP_GAROU_BUILDER /app/target/LoupGarou.jar .
+ADD https://github.com/dmulloy2/ProtocolLib/releases/download/4.5.0/ProtocolLib.jar .
+RUN chmod 777 ProtocolLib.jar
 EXPOSE 25565
-CMD cp -rn /_minecraft/* . && tail -f /dev/null


### PR DESCRIPTION
J'ai modifié la conf Docker pour utiliser une image docker minecraft de SPIGOT.
La CI build automatiquement l'image docker lors d'un push sur master.

Il faut cependant créer un compte Docker pour faire un truc un peu officiel, car pour l'instant ça compile vers https://hub.docker.com/r/atomgenie/loup-garou/tags.

Les modifications faites sur le Dockerfile permettent d'améliorer le temps de création du serveur