### PR TITLE
Anti devo avec les messages de couple '!'

### DIFF
--- a/src/main/java/fr/leomelki/loupgarou/roles/RCupidon.java
+++ b/src/main/java/fr/leomelki/loupgarou/roles/RCupidon.java
@@ -259,7 +259,8 @@ public class RCupidon extends Role{
                                 if(player.getCache().has("inlove")){
                                         player.sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
                                         player.getCache().<LGPlayer>get("inlove").sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
-                                }
+                                }else
+					player.sendMessage("§4Erreur : §cVous n'êtes pas en couple !");
 				e.setCancelled(true);
 			}
 		}

--- a/src/main/java/fr/leomelki/loupgarou/roles/RCupidon.java
+++ b/src/main/java/fr/leomelki/loupgarou/roles/RCupidon.java
@@ -255,9 +255,11 @@ public class RCupidon extends Role{
 	public void onChat(AsyncPlayerChatEvent e) {
 		LGPlayer player = LGPlayer.thePlayer(e.getPlayer());
 		if(player.getGame() == getGame()) {
-			if(e.getMessage().startsWith("!") && player.getCache().has("inlove")) {
-				player.sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
-				player.getCache().<LGPlayer>get("inlove").sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
+			if(e.getMessage().startsWith("!")) {
+                                if(player.getCache().has("inlove")){
+                                        player.sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
+                                        player.getCache().<LGPlayer>get("inlove").sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
+                                }
 				e.setCancelled(true);
 			}
 		}

--- a/src/main/java/fr/leomelki/loupgarou/roles/RCupidon.java
+++ b/src/main/java/fr/leomelki/loupgarou/roles/RCupidon.java
@@ -256,10 +256,10 @@ public class RCupidon extends Role{
 		LGPlayer player = LGPlayer.thePlayer(e.getPlayer());
 		if(player.getGame() == getGame()) {
 			if(e.getMessage().startsWith("!")) {
-                                if(player.getCache().has("inlove")){
-                                        player.sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
-                                        player.getCache().<LGPlayer>get("inlove").sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
-                                }else
+				if(player.getCache().has("inlove")){
+					player.sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
+					player.getCache().<LGPlayer>get("inlove").sendMessage("§d\u2764 "+player.getName()+" §6» §f"+e.getMessage().substring(1));
+				}else
 					player.sendMessage("§4Erreur : §cVous n'êtes pas en couple !");
 				e.setCancelled(true);
 			}


### PR DESCRIPTION
- **Ajout d'une protection dans le cas d'un message commençant par "!" (couple) si la personne n'est pas en couple.**

Les joueurs, si ils n'étaient pas en couple, pouvaient envoyer un message public commençant par !, ce qui prouvait qu'ils n'étaient pas en couple, donnant la possibilité de dévo. La solution la plus simple est de ne simplement pas envoyer le message.